### PR TITLE
Simplify task iterator

### DIFF
--- a/src/main/groovy/com/github/dispader/manifesto/ManifestoPlugin.groovy
+++ b/src/main/groovy/com/github/dispader/manifesto/ManifestoPlugin.groovy
@@ -7,9 +7,6 @@ import org.gradle.jvm.tasks.Jar
 
 class ManifestoPlugin implements Plugin<Project> {
 
-    static boolean jar_configured = false
-    static boolean war_configured = false
-
     void apply(Project project) {
 
         project.extensions.create('manifesto', ManifestoPluginExtension, project)
@@ -17,15 +14,6 @@ class ManifestoPlugin implements Plugin<Project> {
         project.plugins.whenPluginAdded { plugin ->
             project.tasks.findAll { ( it instanceof Jar || it instanceof War ) }.each {
                 it.manifest.with {
-
-                    if ( ( it instanceof Jar ) && jar_configured ) {
-                        project.logger.warn "warning: Jar Manifest already configured."
-                        return
-                    }
-                    if ( ( it instanceof War ) && war_configured ) {
-                        project.logger.warn "warning: War Manifest already configured."
-                        return
-                    }
 
                     def version = new Version()
                     if ( !version ) {
@@ -84,9 +72,6 @@ class ManifestoPlugin implements Plugin<Project> {
                     }
 
                     attributes('Implementation-Timestamp': new Date())
-
-                    if ( it instanceof Jar ) { jar_configured = true }
-                    if ( it instanceof War ) { war_configured = true }
                 }
             }
         }

--- a/src/main/groovy/com/github/dispader/manifesto/ManifestoPlugin.groovy
+++ b/src/main/groovy/com/github/dispader/manifesto/ManifestoPlugin.groovy
@@ -2,7 +2,6 @@ package com.github.dispader.manifesto
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.tasks.bundling.War
 import org.gradle.jvm.tasks.Jar
 
 class ManifestoPlugin implements Plugin<Project> {
@@ -12,7 +11,7 @@ class ManifestoPlugin implements Plugin<Project> {
         project.extensions.create('manifesto', ManifestoPluginExtension, project)
 
         project.plugins.whenPluginAdded { plugin ->
-            project.tasks.findAll { ( it instanceof Jar || it instanceof War ) }.each {
+            project.tasks.withType(Jar).each {
                 it.manifest.with {
 
                     def version = new Version()


### PR DESCRIPTION
This PR builds upon #51.

It appears to be extra work to check task types for both War and Jar because War extends Jar. This also changes to use the built-in `withType` method.