### PR TITLE
Simplify plugin proposal

### DIFF
--- a/src/main/groovy/com/github/dispader/manifesto/ManifestoPlugin.groovy
+++ b/src/main/groovy/com/github/dispader/manifesto/ManifestoPlugin.groovy
@@ -7,9 +7,6 @@ import org.gradle.jvm.tasks.Jar
 
 class ManifestoPlugin implements Plugin<Project> {
 
-    static boolean jar_configured = false
-    static boolean war_configured = false
-
     void apply(Project project) {
 
         project.extensions.create('manifesto', ManifestoPluginExtension, project)
@@ -17,15 +14,6 @@ class ManifestoPlugin implements Plugin<Project> {
         project.plugins.whenPluginAdded { plugin ->
             project.tasks.findAll { ( it instanceof Jar || it instanceof War ) }.each {
                 it.manifest.with {
-
-                    if ( ( it instanceof Jar ) && jar_configured ) {
-                        project.logger.warn "warning: Jar Manifest already configured."
-                        return
-                    }
-                    if ( ( it instanceof War ) && war_configured ) {
-                        project.logger.warn "warning: War Manifest already configured."
-                        return
-                    }
 
                     def version = new Version()
                     if ( !version ) {
@@ -84,9 +72,6 @@ class ManifestoPlugin implements Plugin<Project> {
                     }
 
                     attributes('Implementation-Timestamp': new Date())
-
-                    if ( it instanceof Jar ) { jar_configured = true }
-                    if ( it instanceof War ) { war_configured = true }
                 }
             }
         }

--- a/src/main/groovy/com/github/dispader/manifesto/ManifestoPlugin.groovy
+++ b/src/main/groovy/com/github/dispader/manifesto/ManifestoPlugin.groovy
@@ -2,7 +2,6 @@ package com.github.dispader.manifesto
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.tasks.bundling.War
 import org.gradle.jvm.tasks.Jar
 
 class ManifestoPlugin implements Plugin<Project> {
@@ -12,7 +11,7 @@ class ManifestoPlugin implements Plugin<Project> {
         project.extensions.create('manifesto', ManifestoPluginExtension, project)
 
         project.plugins.whenPluginAdded { plugin ->
-            project.tasks.findAll { ( it instanceof Jar || it instanceof War ) }.each {
+            project.tasks.withType(Jar).each {
                 it.manifest.with {
 
                     def version = new Version()

--- a/src/main/groovy/com/github/dispader/manifesto/ManifestoPlugin.groovy
+++ b/src/main/groovy/com/github/dispader/manifesto/ManifestoPlugin.groovy
@@ -10,67 +10,23 @@ class ManifestoPlugin implements Plugin<Project> {
 
         project.extensions.create('manifesto', ManifestoPluginExtension, project)
 
+        def version = new Version()
+        project.version = version.version
+
         project.plugins.whenPluginAdded { plugin ->
             project.tasks.withType(Jar).each {
                 it.manifest.with {
-
-                    def version = new Version()
-                    if ( !version ) {
-                        project.logger.warn "warning: ${Version.warningText}"
-                        return
-                    }
-
-                    if ( !project.version || project.version == 'unspecified' ) {
-                        project.version = version.version
-                    } else {
-                        project.logger.warn "warning: Manifest version not set."
-                    }
-
-                    attributes('Specification-Title': project.name)
-
-                    if ( project.manifesto?.vendor ) {
-                        attributes('Specification-Vendor': "${project.manifesto.vendor}")
-                    } else {
-                        project.logger.warn "warning: Manifest Specification-Vendor not set."
-                    }
-
-                    if ( version.specification ) {
-                        attributes('Specification-Version': version.specification)
-                    } else if ( project.version ) {
-                        attributes('Specification-Version': "${project.version}")
-                    } else {
-                        project.logger.warn "warning: Manifest Specification-Version not set."
-                    }
-
-                    attributes('Implementation-Title': project.name)
-
-                    if ( project.manifesto?.vendor ) {
-                        attributes('Implementation-Vendor': "${project.manifesto.vendor}")
-                    } else {
-                        project.logger.warn "warning: Manifest Implementation-Vendor not set."
-                    }
-
-                    if ( project.manifesto?.vendor_id ) {
-                        attributes('Implementation-Vendor-Id': "${project.manifesto.vendor_id}")
-                    } else {
-                        project.logger.warn "warning: Manifest Implementation-Vendor-Id not set."
-                    }
-
-                    if ( project.manifesto?.url ) {
-                        attributes('Implementation-URL': "${project.manifesto.url}")
-                    } else {
-                        project.logger.warn "warning: Manifest Implementation-URL not set."
-                    }
-
-                    if ( version.implementation ) {
-                        attributes('Implementation-Version': version.implementation)
-                    } else if ( project.version ) {
-                        attributes('Implementation-Version': "${project.version}")
-                    } else {
-                        project.logger.warn "warning: Manifest Implementation-Version not set."
-                    }
-
-                    attributes('Implementation-Timestamp': new Date())
+                    attributes << [
+                        'Specification-Title'     : project.name,
+                        'Specification-Vendor'    : project.manifesto.vendor,
+                        'Specification-Version'   : version.specification,
+                        'Implementation-Title'    : project.name,
+                        'Implementation-Vendor'   : project.manifesto.vendor,
+                        'Implementation-Vendor-Id': project.manifesto.vendor_id,
+                        'Implementation-URL'      : project.manifesto.url,
+                        'Implementation-Version'  : version.implementation,
+                        'Implementation-Timestamp': new Date()
+                    ]
                 }
             }
         }

--- a/src/main/groovy/com/github/dispader/manifesto/ManifestoPluginExtension.groovy
+++ b/src/main/groovy/com/github/dispader/manifesto/ManifestoPluginExtension.groovy
@@ -4,7 +4,9 @@ import org.gradle.api.Project
 
 class ManifestoPluginExtension {
 
-    String vendor, vendor_id, url
+    String vendor = ""
+    String vendor_id = ""
+    String url = ""
 
     ManifestoPluginExtension(Project project) {
         this.vendor_id = project.group


### PR DESCRIPTION
This is just a proposal. I think ideally the plugin would have little or no logic—like a thin controller.

Some of the logic that was here I think is unnecessary. For example:

- `Version.warningText` is not valid code
- Explicitly declaring a project.version that's different from the source control tag is weird if you're opting into this plugin
- project.manifesto? seem necessary. If the project.manifesto extension doesn't exist, this plugin is fatally broken.

I think there is value in wrapping logic around attributes that might be null, but maybe we should introduce another object to contain the logic that can be tested in isolation.

Thoughts?