### PR TITLE
Update project dependencies

### DIFF
--- a/gradle/code-quality.gradle
+++ b/gradle/code-quality.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'codenarc'
 
 codenarc {
-    toolVersion = '0.27.0'
+    toolVersion = '1.2.1'
     configFile = file('src/check/codenarc/codenarc.groovy')
     sourceSets = [sourceSets.main]
     ignoreFailures = true

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories.maven { url 'https://plugins.gradle.org/m2/' }
     dependencies {
-        classpath 'com.gradle.publish:plugin-publish-plugin:0.9.7'
+        classpath 'com.gradle.publish:plugin-publish-plugin:0.10.0'
     }
 }
 apply plugin: com.gradle.publish.PublishPlugin

--- a/gradle/test-configuration.gradle
+++ b/gradle/test-configuration.gradle
@@ -18,10 +18,11 @@ task integrationTest(type: Test) {
 check.dependsOn integrationTest
 
 dependencies {
-    testCompile('org.spockframework:spock-core:1.1-groovy-2.4') {
-        exclude group: 'org.codehaus.groovy' }
-    testRuntime 'cglib:cglib-nodep:3.2.5'
-    testRuntime 'org.objenesis:objenesis:2.6'
+    testCompile('org.spockframework:spock-core:1.2-groovy-2.4') {
+        exclude group: 'org.codehaus.groovy'
+    }
+    testRuntime 'cglib:cglib-nodep:3.2.8'
+    testRuntime 'org.objenesis:objenesis:3.0.1'
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
Now that we've finally figured out how to update Gradle without breaking the build, we can update project dependencies.

The one exception is [grgit](https://github.com/ajoberstar/grgit), where we're on the last 1.x version.  (2.x and 3.x contain, quite appropriately, breaking changes.)  That'll have to be another set of changes.